### PR TITLE
Use dynamic copyright year on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -349,7 +349,7 @@
     <a href="https://instagram.com/kudulabshq" target="_blank">Instagram</a> ·
     <a href="https://www.threads.net/kudulabshq" target="_blank">Threads</a>
   </div>
-  <div style="color:var(--muted)">© 2025 Kudu Labs, Inc. — Research & collaboration</div>
+  <div style="color:var(--muted)">© <span id="year">2025</span> Kudu Labs, Inc. — Research & collaboration</div>
 </footer>
 
 <!-- MODALS (waitlist, contact, join) -->
@@ -524,6 +524,9 @@ document.querySelectorAll('.tab').forEach(tab=>{
 
 /* cleanup Vanta on unload */
 window.addEventListener('beforeunload', ()=>{ if(vantaEffect) vantaEffect.destroy(); });
+</script>
+<script>
+  document.getElementById('year').textContent = new Date().getFullYear();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show current year in copyright with `<span id="year">` placeholder
- update footer year with a script that sets the span to `new Date().getFullYear()`

## Testing
- `node -e "const fs=require('fs');const {parseHTML}=require('/tmp/linkedom/node_modules/linkedom');const html=fs.readFileSync('index.html','utf8');const {document,window}=parseHTML(html);document.getElementById('year').textContent='placeholder';eval('document.getElementById(\\'year\\').textContent = new Date().getFullYear();');console.log(document.getElementById('year').textContent);"`


------
https://chatgpt.com/codex/tasks/task_e_68ba42774efc8323a44e1e309213b10f